### PR TITLE
Improve frontend API error handling

### DIFF
--- a/frontend/src/hooks/useGrapesEditor.js
+++ b/frontend/src/hooks/useGrapesEditor.js
@@ -270,8 +270,9 @@
      const [showCrop, setShowCrop] = useState(false);
      const [currentRotationHandle, setCurrentRotationHandle] = useState(null);
      const [selectedComponent, setSelectedComponent] = useState(null);
-     const [userImages, setUserImages] = useState([]);
-     const [imagesLoaded, setImagesLoaded] = useState(false);
+    const [userImages, setUserImages] = useState([]);
+    const [imagesLoaded, setImagesLoaded] = useState(false);
+    const [imageError, setImageError] = useState(null);
      const [currentMode, setCurrentMode] = useState(null);
 
      useEffect(() => {
@@ -420,8 +421,14 @@
        /* ────────── Load User Images ────────── */
        const loadUserImages = async () => {
          try {
-           const images = await fetchUserImages();
+           const { success, images, error } = await fetchUserImages();
+           if (!success) {
+             setImageError(error);
+             setImagesLoaded(true);
+             return;
+           }
            setUserImages(images);
+           setImageError(null);
            setImagesLoaded(true);
            
            // Generate and register image blocks
@@ -474,6 +481,7 @@
            }
          } catch (error) {
            console.error('Failed to load user images:', error);
+           setImageError(error.message);
            setImagesLoaded(true); // Mark as loaded even on error
          }
        };
@@ -735,6 +743,6 @@
      // eslint-disable-next-line react-hooks/exhaustive-deps
      }, []);
 
-     return { editorRef, cropData, setCropData, showCrop, userImages, imagesLoaded };
-   }
+    return { editorRef, cropData, setCropData, showCrop, userImages, imagesLoaded, imageError };
+  }
    

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -1,0 +1,8 @@
+export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '';
+
+export function apiUrl(path) {
+  if (!path.startsWith('/')) {
+    path = '/' + path;
+  }
+  return `${API_BASE_URL}${path}`;
+}

--- a/frontend/src/utils/imageService.js
+++ b/frontend/src/utils/imageService.js
@@ -9,17 +9,20 @@
  * Fetch all user images from the backend
  * @returns {Promise<Array>} Array of image objects with metadata
  */
+import { apiUrl } from './api';
+
 export async function fetchUserImages() {
   try {
-    const response = await fetch('/api/user-images');
+    const response = await fetch(apiUrl('/api/user-images'));
     if (!response.ok) {
-      throw new Error(`HTTP error! status: ${response.status}`);
+      const errText = await response.text();
+      return { success: false, error: errText || `HTTP ${response.status}` };
     }
     const data = await response.json();
-    return data.images || [];
+    return { success: true, images: data.images || [] };
   } catch (error) {
     console.error('Failed to fetch user images:', error);
-    return [];
+    return { success: false, error: error.message };
   }
 }
 


### PR DESCRIPTION
## Summary
- add API base URL helper
- return structured errors from `fetchUserImages`, `fetchTemplates`, `fetchTemplate`, `saveTemplate`
- surface template and image errors in CanvasBuilder UI
- store image loading errors in `useGrapesEditor`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6882ea9beaa483279bab61c84ba9ee2d