### PR TITLE
Implement error boundary for CanvasBuilder

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Routes, Route } from 'react-router-dom';
 import Login from './pages/Login';
 import CanvasBuilder from './components/CanvasBuilder/CanvasBuilder';
+import BuilderErrorBoundary from './components/BuilderErrorBoundary';
 import FullscreenDisplay from './pages/FullscreenDisplay';
 import RunnerDisplayPage from './pages/RunnerDisplayPage';
 
@@ -9,7 +10,14 @@ export default function App() {
   return (
     <Routes>
       <Route path="/" element={<Login />} />
-      <Route path="/builder" element={<CanvasBuilder />} />
+      <Route
+        path="/builder"
+        element={(
+          <BuilderErrorBoundary>
+            <CanvasBuilder />
+          </BuilderErrorBoundary>
+        )}
+      />
       <Route path="/display" element={<FullscreenDisplay />} />
       <Route path="/runner-display" element={<RunnerDisplayPage />} />
     </Routes>

--- a/frontend/src/components/BuilderErrorBoundary.jsx
+++ b/frontend/src/components/BuilderErrorBoundary.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+export default class BuilderErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error, info) {
+    console.error('Error in CanvasBuilder:', error, info);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="canvas-builder">
+          <p>An error occurred. Please try again later.</p>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/frontend/src/components/CanvasBuilder/CanvasBuilder.jsx
+++ b/frontend/src/components/CanvasBuilder/CanvasBuilder.jsx
@@ -39,10 +39,8 @@
   
   /* ────────────────────────────────────────────────────────────── */
   
-  export default function CanvasBuilder() {
-    // console.log('CanvasBuilder: Component starting to render');
-  
-    try {
+export default function CanvasBuilder() {
+  // console.log('CanvasBuilder: Component starting to render');
       /* ────────── refs & router ────────── */
       const navigate                = useNavigate();   // reserved if you want to push instead of window.open
       const templateSelectRef       = useRef(null);
@@ -971,13 +969,5 @@
           />
         </div>
       );
-    } catch (error) {
-      // console.error('Error in CanvasBuilder:', error);
-      return (
-        <div className="canvas-builder">
-          <p>An error occurred. Please try again later.</p>
-        </div>
-      );
-    }
   }
-  
+


### PR DESCRIPTION
## Summary
- introduce `BuilderErrorBoundary` component
- wrap `CanvasBuilder` route with `BuilderErrorBoundary`
- remove outer try/catch from `CanvasBuilder`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6882ea9af0c88327876acfc665d562cf